### PR TITLE
docs: Add warning for safari & iOS in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ This is a Next.js application that shows how to authenticate users using WordPre
 
 Apple doesn't allow cross-site cookies, making the login impossible if you are hosting the app & WordPress on **separate domains**.
 
-The **short-term** solution is to disable it from: 
+The **short-term** solution is to disable this option from Safari settings:
 
 `Safari > Settings > Site tracking > Prevent Cross-Site Tracking`.
+
+It will allow you to use the app, but it won't fix the issue for all other Safari / iOS users...
+
 
 The **long-term** solution is to host both the WordPress (back-end) & the webapp (front-end) on the **same domain** (e.g. each one on a different sub-domain).
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Next.js app code for this blog post:
 https://developers.wpengine.com/blog/headless-wordpress-authentication-native-cookies/
 
 This is a Next.js application that shows how to authenticate users using WordPress' own native auth cookies.
+
+## About its usage on Safari & iOS ⚠️
+
+Apple doesn't allow cross-site cookies, making the login impossible if you are hosting the app & WordPress on separate domains.
+
+The **short-term** solution is to disable it from: `Safari > Settings > Site tracking > Prevent Cross-Site Tracking`.
+
+The **long-term** solution is to host both the WordPress (back-end) & the webapp (front-end) on the **same domain** (e.g. each one on a different sub-domain).
+
+See this related [issue](https://github.com/kellenmace/headless-wordpress-authentication-native-cookies/issues/4) for more informations.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ This is a Next.js application that shows how to authenticate users using WordPre
 
 ## About its usage on Safari & iOS ⚠️
 
-Apple doesn't allow cross-site cookies, making the login impossible if you are hosting the app & WordPress on separate domains.
+Apple doesn't allow cross-site cookies, making the login impossible if you are hosting the app & WordPress on **separate domains**.
 
-The **short-term** solution is to disable it from: `Safari > Settings > Site tracking > Prevent Cross-Site Tracking`.
+The **short-term** solution is to disable it from: 
+
+`Safari > Settings > Site tracking > Prevent Cross-Site Tracking`.
 
 The **long-term** solution is to host both the WordPress (back-end) & the webapp (front-end) on the **same domain** (e.g. each one on a different sub-domain).
 


### PR DESCRIPTION
Add a warning about Safari & iOS in the readme.

Everything is explained in this [issue](https://github.com/kellenmace/headless-wordpress-authentication-native-cookies/issues/4).